### PR TITLE
修复 VITE_APP_PUBLIC_PATH 修改为其它路径时显示空白页面的问题

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -30,7 +30,7 @@ const routes = [
 
 // 创建路由实例并传递 `routes` 配置
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory(process.env.VUE_APP_PUBLIC_PATH),
   routes,
   scrollBehavior() {
     // 始终滚动到顶部


### PR DESCRIPTION
修复 VITE_APP_PUBLIC_PATH 修改为其它路径时显示空白页面的问题 https://github.com/CharleeWa/vue3-vant-mobile/issues/20#issue-1422406495