### PR TITLE
fix(dev): :bug: fixed `mock` value judgments (#24)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,8 @@ import mock from './build/mock/createMockServer'
 export default ({ command, mode }: ConfigEnv): UserConfig => {
   const root = process.cwd()
   const env = loadEnv(mode, root)
-
+  const isHttpMock = env.VITE_HTTP_MOCK === 'true'
+  const isViteMock = env.VITE_MOCK === 'true'
   return {
     base: env.VITE_APP_PUBLIC_PATH,
 
@@ -72,7 +73,7 @@ export default ({ command, mode }: ConfigEnv): UserConfig => {
         watch: true,
         mockUrlList: [/api/],
         cwd: process.cwd(),
-        enable: env.VITE_HTTP_MOCK && env.VITE_MOCK && process.env.NODE_ENV !== 'production',
+        enable: isHttpMock && isViteMock && process.env.NODE_ENV !== 'production',
       }),
     ],
 
@@ -103,7 +104,7 @@ export default ({ command, mode }: ConfigEnv): UserConfig => {
     server: {
       host: true,
       port: 3000,
-      proxy: env.VITE_HTTP_MOCK && env.VITE_MOCK && process.env.NODE_ENV !== 'production'
+      proxy: isHttpMock && isViteMock && process.env.NODE_ENV !== 'production'
         ? undefined
         : {
             '/api': {


### PR DESCRIPTION
 env.VITE_HTTP_MOCK ,env.VITE_MOCK 值被设为flase时,会被解析为字符串,导致判断恒等于true