### PR TITLE
fix: '.app-wrappe' Components High overflow causes the page to scroll

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -54,7 +54,7 @@ onMounted(() => {
 <style scoped>
 .app-wrapper {
   width: 100%;
-  height: 100%;
+  height: calc(100% - 46px);
   position: absolute;
   top: 46px;
   left: 0;


### PR DESCRIPTION
```
.app-wrapper {
  ...
  height: 100%;
  ...
}
```
'.app-wrappe' 的高度是 100%，导致首页会产生滚动，个人觉得不产生滚动体验更好。

```
.app-wrapper {
  ...
  height: calc(100% - 46px);
  ...
}
```