### PR TITLE
fix: Routing history judgment problem

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -3,7 +3,7 @@ const route = useRoute()
 const router = useRouter()
 
 function onBack() {
-  if (history.length > 1)
+  if (window.history.state.back)
     history.back()
   else
     router.replace('/')


### PR DESCRIPTION
NavBar组件的onBack方法里：`if (history.length > 1)` 判读有问题，改为`if (window.history.state.back)` 可解决。
